### PR TITLE
fix: add Resend dependency and set node runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
+    "resend": "^3.4.0",
     "tailwind-merge": "^2.6.0",
     "zod": "^3.24.1"
   },

--- a/src/app/api/submit-payment/route.ts
+++ b/src/app/api/submit-payment/route.ts
@@ -1,0 +1,19 @@
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { Resend } from 'resend';
+
+export async function POST(request: Request) {
+  const body = await request.json();
+
+  const resend = new Resend(process.env.RESEND_API_KEY);
+
+  await resend.emails.send({
+    from: process.env.FROM_EMAIL ?? 'no-reply@example.com',
+    to: process.env.ADMIN_EMAIL ?? '',
+    subject: 'Payment submitted',
+    text: JSON.stringify(body),
+  });
+
+  return NextResponse.json({ message: 'Email sent' });
+}


### PR DESCRIPTION
## Summary
- add `resend` to project dependencies
- add `submit-payment` API route with Node.js runtime and Resend integration

## Testing
- `pnpm test` *(fails: Unable to find an element with the text: /A starter for Next.js/i)*

------
https://chatgpt.com/codex/tasks/task_e_68c5af16b6ec8320b79b9e7c145034a6