### PR TITLE
feat: add reCAPTCHA verification to payment form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@
 # Ideally, don't add them to production deployment envs
 # !STARTERCONF Change to true if you want to log data
 NEXT_PUBLIC_SHOW_LOGGER="false"
+# Google reCAPTCHA
+NEXT_PUBLIC_RECAPTCHA_SITE_KEY=""
+RECAPTCHA_SECRET=""


### PR DESCRIPTION
## Summary
- load reCAPTCHA on landing page and require completion before form submit
- validate reCAPTCHA token in submit-payment API route
- document required reCAPTCHA environment variables

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f2ca9cb08320be202e6ead23b33d