### PR TITLE
fix(nav): route menu to Telegram channel/DM and in-page sections + smooth scroll

### DIFF
--- a/src/app/CardicNexusLanding.jsx
+++ b/src/app/CardicNexusLanding.jsx
@@ -1,22 +1,22 @@
 'use client';
 import Image from 'next/image';
-import React, { useState } from 'react';
 
 import BrandLogo from '@/components/BrandLogo';
 
 export default function CardicNexusLanding() {
-  const [showCheckout, setShowCheckout] = useState(false);
-  const openCheckout = (e) => {
-    e.preventDefault();
-    setShowCheckout(true);
-  };
-  const closeCheckout = () => setShowCheckout(false);
   const copy = async (text) => {
     try {
       await navigator.clipboard.writeText(text);
       alert('Copied');
     } catch {
       /* ignore */
+    }
+  };
+  const scrollToPay = (e) => {
+    e.preventDefault();
+    const el = document.querySelector('#pay');
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
   };
   const handleSubmit = async (e) => {
@@ -30,7 +30,6 @@ export default function CardicNexusLanding() {
       if (res.ok) {
         alert('Success!');
         e.target.reset();
-        setShowCheckout(false);
       } else {
         alert('Error submitting form');
       }
@@ -95,7 +94,7 @@ export default function CardicNexusLanding() {
           <a className='cnx-btn cnx-btn-ghost' href='#projects'>
             Explore Projects
           </a>
-          <a className='cnx-btn cnx-btn-blue' href='#pricing'>
+          <a className='cnx-btn cnx-btn-blue' href='#pay' onClick={scrollToPay}>
             Join Premium
           </a>
         </div>
@@ -124,8 +123,8 @@ export default function CardicNexusLanding() {
               <div className='cnx-card-actions'>
                 <a
                   className='cnx-btn cnx-btn-ghost'
-                  href='#'
-                  onClick={openCheckout}
+                  href='#pay'
+                  onClick={scrollToPay}
                 >
                   Buy
                 </a>
@@ -164,8 +163,8 @@ export default function CardicNexusLanding() {
             <div className='cnx-card-actions' style={{ marginTop: 12 }}>
               <a
                 className='cnx-btn cnx-btn-blue'
-                href='#'
-                onClick={openCheckout}
+                href='#pay'
+                onClick={scrollToPay}
               >
                 Get 2.0
               </a>
@@ -184,8 +183,8 @@ export default function CardicNexusLanding() {
             <div className='cnx-card-actions' style={{ marginTop: 12 }}>
               <a
                 className='cnx-btn cnx-btn-blue'
-                href='#'
-                onClick={openCheckout}
+                href='#pay'
+                onClick={scrollToPay}
               >
                 Get 2.1
               </a>
@@ -204,8 +203,8 @@ export default function CardicNexusLanding() {
             <div className='cnx-card-actions' style={{ marginTop: 12 }}>
               <a
                 className='cnx-btn cnx-btn-blue'
-                href='#'
-                onClick={openCheckout}
+                href='#pay'
+                onClick={scrollToPay}
               >
                 Get 2.3
               </a>
@@ -233,8 +232,8 @@ export default function CardicNexusLanding() {
             </ul>
             <a
               className='cnx-btn cnx-btn-ghost'
-              href='#'
-              onClick={openCheckout}
+              href='#pay'
+              onClick={scrollToPay}
             >
               Subscribe
             </a>
@@ -259,10 +258,127 @@ export default function CardicNexusLanding() {
               <li>Premium signals</li>
               <li>Priority support</li>
             </ul>
-            <a className='cnx-btn cnx-btn-blue' href='#' onClick={openCheckout}>
+            <a
+              className='cnx-btn cnx-btn-blue'
+              href='#pay'
+              onClick={scrollToPay}
+            >
               Join
             </a>
           </article>
+        </div>
+      </section>
+
+      {/* PAYMENT DETAILS */}
+      <section id='pay' className='cnx-section'>
+        <div className='cnx-pay-panel'>
+          <h2>Join Premium</h2>
+          <p className='cnx-text'>
+            Crypto payments (USDT / ETH / BTC). Pick any address, make payment,
+            then submit your details + proof.
+          </p>
+
+          <div className='cnx-pay-grid'>
+            <div className='cnx-pay-card'>
+              <h3>USDT (ERC-20)</h3>
+              <div className='cnx-address-row'>
+                <span className='cnx-address'>{usdt}</span>
+                <button
+                  className='cnx-copy'
+                  type='button'
+                  onClick={() => copy(usdt)}
+                >
+                  Copy
+                </button>
+              </div>
+              <div className='cnx-note'>Network: ERC-20 only.</div>
+              <div className='cnx-qr'>
+                <Image
+                  src={`https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${usdt}`}
+                  width={120}
+                  height={120}
+                  alt='usdt'
+                  unoptimized
+                />
+              </div>
+            </div>
+            <div className='cnx-pay-card'>
+              <h3>ETH (ERC-20)</h3>
+              <div className='cnx-address-row'>
+                <span className='cnx-address'>{eth}</span>
+                <button
+                  className='cnx-copy'
+                  type='button'
+                  onClick={() => copy(eth)}
+                >
+                  Copy
+                </button>
+              </div>
+              <div className='cnx-note'>Network: ERC-20 only.</div>
+              <div className='cnx-qr'>
+                <Image
+                  src={`https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${eth}`}
+                  width={120}
+                  height={120}
+                  alt='eth'
+                  unoptimized
+                />
+              </div>
+            </div>
+            <div className='cnx-pay-card'>
+              <h3>BTC</h3>
+              <div className='cnx-address-row'>
+                <span className='cnx-address'>{btc}</span>
+                <button
+                  className='cnx-copy'
+                  type='button'
+                  onClick={() => copy(btc)}
+                >
+                  Copy
+                </button>
+              </div>
+              <div className='cnx-note'>Network: BTC (SegWit).</div>
+              <div className='cnx-qr'>
+                <Image
+                  src={`https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${btc}`}
+                  width={120}
+                  height={120}
+                  alt='btc'
+                  unoptimized
+                />
+              </div>
+            </div>
+          </div>
+
+          <form className='cnx-form' onSubmit={handleSubmit}>
+            <h3 className='cnx-pay-form-title'>Submit Payment Proof</h3>
+            <input type='text' name='name' placeholder='Full Name' required />
+            <input type='email' name='email' placeholder='Email' required />
+            <input
+              type='text'
+              name='tradingview'
+              placeholder='TradingView Username'
+              required
+            />
+            <input
+              type='text'
+              name='contact'
+              placeholder='Contact (Telegram @ or WhatsApp)'
+            />
+            <input
+              type='text'
+              name='txHash'
+              placeholder='Transaction Hash/ID (optional)'
+            />
+            <textarea name='notes' placeholder='Notes (optional)' rows={3} />
+            <input
+              type='file'
+              name='proof'
+              accept='image/*,application/pdf'
+              required
+            />
+            <button type='submit'>Submit</button>
+          </form>
         </div>
       </section>
 
@@ -321,111 +437,6 @@ export default function CardicNexusLanding() {
         <div className='cnx-line' />© {new Date().getFullYear()} Cardic Nexus.
         All rights reserved.
       </footer>
-
-      {showCheckout && (
-        <div className='cnx-modal' onClick={closeCheckout}>
-          <div
-            className='cnx-modal-content'
-            onClick={(e) => e.stopPropagation()}
-          >
-            <button className='cnx-close' onClick={closeCheckout}>
-              ×
-            </button>
-            <h3 className='cnx-modal-title'>
-              Crypto Payments (USDT / ETH / BTC)
-            </h3>
-            <p className='cnx-modal-sub'>
-              Pick any address, make payment, then submit your details + proof.
-            </p>
-            <div className='cnx-pay-grid'>
-              <div className='cnx-pay-card'>
-                <h4>USDT (ERC-20)</h4>
-                <div className='cnx-address-row'>
-                  <span className='cnx-address'>{usdt}</span>
-                  <button className='cnx-copy' onClick={() => copy(usdt)}>
-                    Copy
-                  </button>
-                </div>
-                <div className='cnx-note'>Network: ERC-20 only.</div>
-                <div className='cnx-qr'>
-                  <Image
-                    src={`https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${usdt}`}
-                    width={120}
-                    height={120}
-                    alt='usdt'
-                    unoptimized
-                  />
-                </div>
-              </div>
-              <div className='cnx-pay-card'>
-                <h4>ETH (ERC-20)</h4>
-                <div className='cnx-address-row'>
-                  <span className='cnx-address'>{eth}</span>
-                  <button className='cnx-copy' onClick={() => copy(eth)}>
-                    Copy
-                  </button>
-                </div>
-                <div className='cnx-note'>Network: ERC-20 only.</div>
-                <div className='cnx-qr'>
-                  <Image
-                    src={`https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${eth}`}
-                    width={120}
-                    height={120}
-                    alt='eth'
-                    unoptimized
-                  />
-                </div>
-              </div>
-              <div className='cnx-pay-card'>
-                <h4>BTC</h4>
-                <div className='cnx-address-row'>
-                  <span className='cnx-address'>{btc}</span>
-                  <button className='cnx-copy' onClick={() => copy(btc)}>
-                    Copy
-                  </button>
-                </div>
-                <div className='cnx-qr'>
-                  <Image
-                    src={`https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${btc}`}
-                    width={120}
-                    height={120}
-                    alt='btc'
-                    unoptimized
-                  />
-                </div>
-              </div>
-            </div>
-            <form className='cnx-form' onSubmit={handleSubmit}>
-              <input type='text' name='name' placeholder='Full Name' required />
-              <input type='email' name='email' placeholder='Email' required />
-              <input
-                type='text'
-                name='tradingview'
-                placeholder='TradingView Username'
-                required
-              />
-              <input
-                type='text'
-                name='contact'
-                placeholder='Contact (Telegram @ or WhatsApp)'
-              />
-              <input
-                type='text'
-                name='txHash'
-                placeholder='Transaction Hash/ID (optional)'
-              />
-              <textarea name='notes' placeholder='Notes (optional)' rows={3} />
-              <input
-                type='file'
-                name='proof'
-                accept='image/*,application/pdf'
-                required
-              />
-              <button type='submit'>Submit</button>
-            </form>
-          </div>
-        </div>
-      )}
 
       {/* Scoped CSS (no Tailwind) */}
       <style>{`
@@ -499,21 +510,74 @@ export default function CardicNexusLanding() {
 
         .cnx-tagline{color:var(--muted); margin-top:12px; text-align:center}
 
-        .cnx-modal{position:fixed; inset:0; background:rgba(0,0,0,.6); display:flex; align-items:center; justify-content:center; z-index:99; padding:20px}
-        .cnx-modal-content{background:#fff; color:#000; border-radius:10px; padding:20px; width:100%; max-width:600px; max-height:90vh; overflow-y:auto; position:relative}
-        .cnx-close{position:absolute; top:10px; right:10px; background:none; border:none; font-size:24px; cursor:pointer}
-        .cnx-modal-title{margin:0; font-size:20px; font-weight:700}
-        .cnx-modal-sub{color:#555; margin:6px 0 16px; font-size:14px}
-        .cnx-pay-grid{display:grid; gap:12px; margin-bottom:16px}
-        .cnx-pay-card{border:1px solid #ddd; border-radius:8px; padding:12px}
-        .cnx-pay-card h4{margin:0 0 6px}
-        .cnx-address-row{display:flex; justify-content:space-between; align-items:center; font-size:13px; gap:8px}
-        .cnx-address{word-break:break-all; font-family:monospace}
-        .cnx-copy{background:#000; color:#fff; border:none; padding:4px 8px; border-radius:4px; cursor:pointer}
-        .cnx-qr{margin-top:8px; display:flex; justify-content:center}
-        .cnx-form{display:flex; flex-direction:column; gap:10px}
-        .cnx-form input, .cnx-form textarea{width:100%; border:1px solid #ccc; padding:8px; border-radius:4px; font-family:inherit}
-        .cnx-form button{background:#000; color:#fff; border:none; padding:10px; border-radius:6px; cursor:pointer}
+        .cnx-pay-panel{
+          background:rgba(255,255,255,.04);
+          border:1px solid rgba(255,255,255,.12);
+          border-radius:22px;
+          padding:24px;
+          box-shadow:0 0 0 1px rgba(245,199,107,.25), 0 0 28px rgba(16,165,255,.12);
+        }
+        .cnx-pay-panel h2{margin:0 0 10px}
+        .cnx-pay-panel .cnx-text{margin:0 0 20px}
+        .cnx-pay-grid{
+          display:grid;
+          gap:16px;
+          grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
+          margin-bottom:24px;
+        }
+        .cnx-pay-card{
+          background:rgba(255,255,255,.05);
+          border:1px solid rgba(255,255,255,.14);
+          border-radius:16px;
+          padding:16px;
+          display:flex;
+          flex-direction:column;
+          gap:10px;
+        }
+        .cnx-pay-card h3{margin:0}
+        .cnx-address-row{
+          display:flex;
+          justify-content:space-between;
+          align-items:center;
+          font-size:13px;
+          gap:8px;
+        }
+        .cnx-address{word-break:break-all; font-family:monospace; color:#f3f5ff}
+        .cnx-copy{
+          background:rgba(16,165,255,.15);
+          color:#fff;
+          border:1px solid rgba(16,165,255,.4);
+          padding:4px 10px;
+          border-radius:8px;
+          cursor:pointer;
+          transition:.2s;
+        }
+        .cnx-copy:hover{background:rgba(16,165,255,.28)}
+        .cnx-qr{margin-top:4px; display:flex; justify-content:center}
+        .cnx-pay-form-title{margin:0; font-size:18px; font-weight:700}
+        .cnx-form{display:grid; gap:12px}
+        .cnx-form input, .cnx-form textarea{
+          width:100%;
+          border:1px solid rgba(255,255,255,.18);
+          background:rgba(255,255,255,.05);
+          color:#fff;
+          padding:10px;
+          border-radius:12px;
+          font-family:inherit;
+        }
+        .cnx-form input::placeholder, .cnx-form textarea::placeholder{color:rgba(255,255,255,.55)}
+        .cnx-form textarea{resize:vertical; min-height:120px}
+        .cnx-form button{
+          background:var(--blue);
+          color:#000;
+          border:none;
+          padding:12px;
+          border-radius:12px;
+          font-weight:700;
+          cursor:pointer;
+          transition:.2s;
+        }
+        .cnx-form button:hover{filter:brightness(1.08)}
 
       `}</style>
     </div>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,31 +1,58 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { type MouseEvent, useState } from 'react';
 
 import BrandLogo from './BrandLogo';
+
+const TELEGRAM_CHANNEL = 'https://t.me/cardicnexus';
+const TELEGRAM_DM = 'https://t.me/realcardic1';
 
 export default function NavBar() {
   const [open, setOpen] = useState(false);
 
+  const onNavClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    const href = (e.currentTarget.getAttribute('href') || '').trim();
+    if (href.startsWith('#')) {
+      e.preventDefault();
+      const el = document.querySelector(href);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    }
+  };
+
+  const onMobileNavClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    onNavClick(e);
+    setOpen(false);
+  };
+
   return (
     <header className='cnx-nav'>
-      <div className='inner'>
-        <Link href='/' className='logo' aria-label='Cardic Nexus home'>
+      <div className='cnx-nav-inner'>
+        <Link href='/' className='brand' aria-label='Cardic Nexus – Home'>
           <BrandLogo size='md' />
         </Link>
 
-        <nav className='links'>
-          <Link href='/projects'>Projects</Link>
-          <Link href='/projects/heat'>CARDIC Heat</Link>
-          <Link href='/pricing'>Pricing</Link>
-          <Link href='/contact'>Contact</Link>
+        <nav className='cnx-links'>
+          <a href={TELEGRAM_CHANNEL} target='_blank' rel='noreferrer'>
+            Projects
+          </a>
+          <a href='#heat' onClick={onNavClick}>
+            CARDIC Heat
+          </a>
+          <a href='#pricing' onClick={onNavClick}>
+            Pricing
+          </a>
+          <a href={TELEGRAM_DM} target='_blank' rel='noreferrer'>
+            Contact
+          </a>
         </nav>
 
-        <div className='actions'>
-          <Link href='/pricing' className='btn blue'>
+        <div className='cnx-nav-actions'>
+          <a href='#pay' onClick={onNavClick} className='cnx-btn cnx-btn-blue'>
             Join Premium
-          </Link>
+          </a>
           <button
             className='burger'
             aria-label='Open menu'
@@ -46,18 +73,35 @@ export default function NavBar() {
         }}
       >
         <nav className='sheetNav'>
-          <Link href='/projects' onClick={() => setOpen(false)}>
+          <a
+            href={TELEGRAM_CHANNEL}
+            target='_blank'
+            rel='noreferrer'
+            onClick={() => setOpen(false)}
+          >
             Projects
-          </Link>
-          <Link href='/projects/heat' onClick={() => setOpen(false)}>
+          </a>
+          <a href='#heat' onClick={onMobileNavClick}>
             CARDIC Heat
-          </Link>
-          <Link href='/pricing' onClick={() => setOpen(false)}>
+          </a>
+          <a href='#pricing' onClick={onMobileNavClick}>
             Pricing
-          </Link>
-          <Link href='/contact' onClick={() => setOpen(false)}>
+          </a>
+          <a
+            href={TELEGRAM_DM}
+            target='_blank'
+            rel='noreferrer'
+            onClick={() => setOpen(false)}
+          >
             Contact
-          </Link>
+          </a>
+          <a
+            href='#pay'
+            onClick={onMobileNavClick}
+            className='cnx-btn cnx-btn-blue'
+          >
+            Join Premium
+          </a>
         </nav>
       </div>
 
@@ -70,7 +114,7 @@ export default function NavBar() {
           background: rgba(0, 0, 0, 0.35);
           border-bottom: 1px solid rgba(245, 199, 107, 0.18);
         }
-        .inner {
+        .cnx-nav-inner {
           max-width: 1100px;
           margin: 0 auto;
           padding: 12px 16px;
@@ -79,26 +123,26 @@ export default function NavBar() {
           justify-content: space-between;
           gap: 16px;
         }
-        .links {
+        .cnx-links {
           display: flex;
           gap: 16px;
           align-items: center;
         }
-        .links a {
+        .cnx-links a {
           color: #cfd3dc;
           text-decoration: none;
           font-size: 14px;
         }
-        .links a:hover {
+        .cnx-links a:hover {
           color: #fff;
         }
 
-        .actions {
+        .cnx-nav-actions {
           display: flex;
           gap: 10px;
           align-items: center;
         }
-        .btn {
+        .cnx-btn {
           display: inline-block;
           padding: 10px 14px;
           border-radius: 14px;
@@ -106,14 +150,14 @@ export default function NavBar() {
           color: #fff;
           text-decoration: none;
         }
-        .btn.blue {
+        .cnx-btn.cnx-btn-blue {
           background: #10a5ff;
           color: #000;
           font-weight: 800;
           border-color: transparent;
           box-shadow: 0 0 24px rgba(16, 165, 255, 0.35);
         }
-        .btn.blue:hover {
+        .cnx-btn.cnx-btn-blue:hover {
           filter: brightness(1.08);
         }
 
@@ -135,7 +179,7 @@ export default function NavBar() {
         }
 
         @media (max-width: 900px) {
-          .links {
+          .cnx-links {
             display: none;
           }
           .burger {
@@ -185,6 +229,10 @@ export default function NavBar() {
           transform: scale(0.98);
           background: rgba(16, 165, 255, 0.12);
           border-color: rgba(16, 165, 255, 0.35);
+        }
+
+        :global(section[id]) {
+          scroll-margin-top: 84px;
         }
       `}</style>
     </header>


### PR DESCRIPTION
## Summary
- update the header navigation to use Telegram links and in-page anchors with smooth scrolling and sticky-header offsets
- sync the mobile sheet menu and join button with the new destinations while keeping the design styling consistent
- expose the crypto payment section on the landing page with the `#pay` anchor and update related CTAs to scroll to it

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9828489a48320844c8c972c6ab6f5