### PR TITLE
chore: update CARDIC NEXUS metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,46 @@ import './globals.css';
 import NavBar from '@/components/NavBar';
 
 export const metadata: Metadata = {
-  title: 'Cardic Nexus',
-  description: 'AI • Trading • Innovation — for retail traders.',
+  metadataBase: new URL('https://www.cardicnex.us'),
+  title: {
+    default: 'CARDIC NEXUS — AI • Trading',
+    template: '%s | CARDIC NEXUS',
+  },
+  description:
+    'AI • Trading • Innovation for retail traders. Precision indicators, EAs, and premium signals.',
+  openGraph: {
+    type: 'website',
+    url: '/',
+    siteName: 'CARDIC NEXUS',
+    title: 'CARDIC NEXUS — AI • Trading',
+    description:
+      'AI • Trading • Innovation for retail traders. Precision indicators, EAs, and premium signals.',
+    images: [
+      {
+        url: '/images/og.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'CARDIC NEXUS gold/blue logo',
+      },
+    ],
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'CARDIC NEXUS — AI • Trading',
+    description:
+      'AI • Trading • Innovation for retail traders. Precision indicators, EAs, and premium signals.',
+    images: ['/images/og.jpg'],
+    site: '@CARDICNEXUS',
+    creator: '@CARDICNEXUS',
+  },
+  alternates: {
+    canonical: 'https://www.cardicnex.us',
+  },
+  icons: {
+    icon: '/favicon/favicon.ico',
+    apple: '/favicon/apple-touch-icon.png',
+  },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary
- replace the default layout metadata with CARDIC NEXUS titles, descriptions, and Open Graph/Twitter settings
- point preview cards at the existing /images/og.jpg asset and add the canonical URL
- register the favicon and apple-touch icon paths in the metadata

## Testing
- not run (metadata change only)


------
https://chatgpt.com/codex/tasks/task_e_68c98f546e808320be61ad79d62ede82