### PR TITLE
feat: restore hero text branding

### DIFF
--- a/src/app/CardicNexusLanding.jsx
+++ b/src/app/CardicNexusLanding.jsx
@@ -1,8 +1,6 @@
 'use client';
 import Image from 'next/image';
 
-import BrandLogo from '@/components/BrandLogo';
-
 export default function CardicNexusLanding() {
   const copy = async (text) => {
     try {
@@ -82,22 +80,24 @@ export default function CardicNexusLanding() {
 
       {/* HERO */}
       <section className='cnx-hero'>
-        <div
-          style={{ display: 'flex', justifyContent: 'center', marginTop: 8 }}
-        >
-          <BrandLogo size='lg' />
-        </div>
+        <h1>
+          <span className='cnx-text-gold'>CARDIC</span>{' '}
+          <span className='cnx-text-blue'>NEXUS</span>
+        </h1>
         <p className='cnx-tag'>
           AI • Trading • Innovation — for retail traders.
         </p>
+
         <div className='cnx-row'>
           <a className='cnx-btn cnx-btn-ghost' href='#projects'>
             Explore Projects
           </a>
-          <a className='cnx-btn cnx-btn-blue' href='#pay' onClick={scrollToPay}>
+          <a className='cnx-btn cnx-btn-blue' href='#pricing'>
             Join Premium
           </a>
         </div>
+
+        {/* Keep your new line here */}
         <div className='cnx-note'>
           💙 GOODLUCK ON YOUR TRADING JOURNEY — WE WANT TO SEE YOU WIN
         </div>

--- a/src/components/BrandLogo.tsx
+++ b/src/components/BrandLogo.tsx
@@ -1,33 +1,29 @@
-// src/components/BrandLogo.tsx
-import Image from "next/image";
+import Image from 'next/image';
 
 type BrandLogoProps = {
-  size?: "sm" | "md" | "lg";
+  size?: 'sm' | 'md' | 'lg';
   className?: string;
 };
 
-const SIZE: Record<NonNullable<BrandLogoProps["size"]>, number> = {
-  sm: 40,  // small circular logo
-  md: 56,
-  lg: 72,
+const SIZE_MAP: Record<
+  NonNullable<BrandLogoProps['size']>,
+  { width: number; height: number }
+> = {
+  sm: { width: 100, height: 100 },
+  md: { width: 140, height: 140 },
+  lg: { width: 200, height: 200 },
 };
 
-export default function BrandLogo({ size = "sm", className }: BrandLogoProps) {
-  const px = SIZE[size];
+export default function BrandLogo({ size = 'sm', className }: BrandLogoProps) {
+  const s = SIZE_MAP[size];
   return (
     <Image
-      src="/images/cardic-nexus-header.png"
-      alt="CARDIC NEXUS"
-      width={px}
-      height={px}
-      priority
+      src='/images/cardic-nexus-header.png'
+      alt='CARDIC NEXUS'
+      width={s.width}
+      height={s.height}
       className={className}
-      style={{
-        borderRadius: "50%",
-        objectFit: "cover",
-        boxShadow: "0 0 10px rgba(16,165,255,.35)",
-        background: "transparent",
-      }}
+      priority
     />
   );
 }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import Link from 'next/link';
 import { type MouseEvent, useState } from 'react';
 
-import BrandLogo from './BrandLogo';
+import BrandLogo from '@/components/BrandLogo';
 
 const TELEGRAM_CHANNEL = 'https://t.me/cardicnexus';
 const TELEGRAM_DM = 'https://t.me/realcardic1';
@@ -30,9 +29,12 @@ export default function NavBar() {
   return (
     <header className='cnx-nav'>
       <div className='cnx-nav-inner'>
-        <Link href='/' className='brand' aria-label='Cardic Nexus – Home'>
-          <BrandLogo size='md' />
-        </Link>
+        <a href='/' className='brand' aria-label='Cardic Nexus — Home'>
+          <BrandLogo
+            size='sm'
+            className='rounded-full overflow-hidden ring-1 ring-white/10 shadow-[0_0_18px_rgba(245,199,107,0.25)]'
+          />
+        </a>
 
         <nav className='cnx-links'>
           <a href={TELEGRAM_CHANNEL} target='_blank' rel='noreferrer'>


### PR DESCRIPTION
## Summary
- restore the hero heading to display the CARDIC NEXUS text lockup with updated CTAs
- render the nav brand with the small circular BrandLogo component
- update BrandLogo sizing to support circular styling via className props

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9cd5fb8588320beae1735ebe081d6