### PR TITLE
feat: restyle hero heading

### DIFF
--- a/src/app/CardicNexusLanding.jsx
+++ b/src/app/CardicNexusLanding.jsx
@@ -1,8 +1,6 @@
 'use client';
 import Image from 'next/image';
 
-import BrandLogo from '@/components/BrandLogo';
-
 export default function CardicNexusLanding() {
   const copy = async (text) => {
     try {
@@ -82,11 +80,10 @@ export default function CardicNexusLanding() {
 
       {/* HERO */}
       <section className='cnx-hero'>
-        <div
-          style={{ display: 'flex', justifyContent: 'center', marginTop: 8 }}
-        >
-          <BrandLogo size='lg' />
-        </div>
+        <h1 className='heroTitle'>
+          <span className='heroGold'>CARDIC</span>{' '}
+          <span className='heroBlue'>NEXUS</span>
+        </h1>
         <p className='cnx-tag'>
           AI • Trading • Innovation — for retail traders.
         </p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,2 +1,42 @@
 @import '../styles/globals.css';
 @import '../styles/colors.css';
+
+/* ===== CARDIC NEXUS center title ===== */
+.heroTitle {
+  margin: 0 auto 8px;
+  text-align: center;
+  font-size: 56px; /* tweak if you want it bigger/smaller */
+  line-height: 1.05;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+}
+
+/* metallic gold “CARDIC” */
+.heroGold {
+  background: linear-gradient(
+    180deg,
+    #ffd27a 0%,
+    #f5c76b 45%,
+    #c98e3a 70%,
+    #b77a2b 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 0 0 18px rgba(245, 199, 107, 0.35);
+}
+
+/* neon blue “NEXUS” */
+.heroBlue {
+  color: #10a5ff;
+  text-shadow: 0 0 10px rgba(16, 165, 255, 0.55),
+    0 0 22px rgba(16, 165, 255, 0.35);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 480px) {
+  .heroTitle {
+    font-size: 38px;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the hero logo with a text-based CARDIC NEXUS heading
- add gradient gold and neon blue hero styles to the global stylesheet for the new heading

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d14d7b408320b52ed73e28957eaa