### PR TITLE
chore: point favicon metadata to new asset

### DIFF
--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -1,19 +1,19 @@
 {
-  "name": "",
-  "short_name": "",
+  "name": "CARDIC NEXUS",
+  "short_name": "CARDIC NEXUS",
   "icons": [
     {
-      "src": "/favicon/android-chrome-192x192.png",
+      "src": "/favicon/favicon.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/favicon/android-chrome-512x512.png",
+      "src": "/favicon/favicon.png",
       "sizes": "512x512",
       "type": "image/png"
     }
   ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "background_color": "#000000",
   "display": "standalone"
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,8 +43,9 @@ export const metadata: Metadata = {
     canonical: 'https://www.cardicnex.us',
   },
   icons: {
-    icon: '/favicon/favicon.ico',
-    apple: '/favicon/apple-touch-icon.png',
+    icon: '/favicon/favicon.png',
+    shortcut: '/favicon/favicon.png',
+    apple: '/favicon/favicon.png',
   },
 };
 


### PR DESCRIPTION
## Summary
- update the app router metadata icons to reference /favicon/favicon.png for all browsers
- refresh the web app manifest to use the same favicon asset and dark theme colors

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68c9e83d737883208ea2bcec84619f82