### PR TITLE
Add PaymentSheet modal for premium checkout interactions

### DIFF
--- a/src/app/CardicNexusLanding.jsx
+++ b/src/app/CardicNexusLanding.jsx
@@ -1,7 +1,16 @@
 'use client';
 import Image from 'next/image';
+import { useState } from 'react';
+
+import PaymentSheet from '@/components/PaymentSheet';
 
 export default function CardicNexusLanding() {
+  const [payOpen, setPayOpen] = useState(false);
+  const [plan, setPlan] = useState(null);
+  const openPay = (p) => {
+    setPlan(p);
+    setPayOpen(true);
+  };
   const copy = async (text) => {
     try {
       await navigator.clipboard.writeText(text);
@@ -43,6 +52,11 @@ export default function CardicNexusLanding() {
       status: 'Soon',
       text: 'Real-time psychology, liquidity battles, predictive zones.',
       tags: ['Psychology', 'Liquidity', 'AI'],
+      plan: {
+        id: 'oracle-1',
+        title: 'CARDIC Oracle 1.0',
+        price: 'Coming Soon',
+      },
     },
     {
       title: 'Cardic Heat Zones™',
@@ -50,6 +64,11 @@ export default function CardicNexusLanding() {
       status: 'Live',
       text: 'Smart money zones with alerts.',
       tags: ['SMC', 'Zones', 'Alerts'],
+      plan: {
+        id: 'heat-zones',
+        title: 'CARDIC Heat Zones™',
+        price: 'From $99',
+      },
     },
     {
       title: 'Cardic Spider Web™',
@@ -57,6 +76,11 @@ export default function CardicNexusLanding() {
       status: 'In Dev',
       text: 'Dynamic SR + Fibonacci + Order Blocks.',
       tags: ['Fib', 'OB', 'Grid'],
+      plan: {
+        id: 'spider-web',
+        title: 'Cardic Spider Web™',
+        price: 'Coming Soon',
+      },
     },
     {
       title: 'Premium Signals',
@@ -64,6 +88,11 @@ export default function CardicNexusLanding() {
       status: 'Live',
       text: 'Daily gold/FX/crypto signals with risk notes.',
       tags: ['Gold', 'Forex', 'Crypto'],
+      plan: {
+        id: 'premium-signals',
+        title: 'Premium Signals',
+        price: '$49/mo',
+      },
     },
   ];
 
@@ -81,8 +110,8 @@ export default function CardicNexusLanding() {
       {/* HERO */}
       <section className='cnx-hero'>
         <h1 className='heroTitle'>
-          <span className='heroGold'>CARDIC</span>{' '}
-          <span className='heroBlue'>NEXUS</span>
+          <span className='cnx-text-gold heroGold'>CARDIC</span>{' '}
+          <span className='cnx-text-blue heroBlue'>NEXUS</span>
         </h1>
         <p className='cnx-tag'>
           AI • Trading • Innovation — for retail traders.
@@ -91,9 +120,19 @@ export default function CardicNexusLanding() {
           <a className='cnx-btn cnx-btn-ghost' href='#projects'>
             Explore Projects
           </a>
-          <a className='cnx-btn cnx-btn-blue' href='#pay' onClick={scrollToPay}>
+          <button
+            className='cnx-btn cnx-btn-blue'
+            type='button'
+            onClick={() =>
+              openPay({
+                id: 'all-access',
+                title: 'All-Access',
+                price: '$179/mo',
+              })
+            }
+          >
             Join Premium
-          </a>
+          </button>
         </div>
         <div className='cnx-note'>
           💙 GOODLUCK ON YOUR TRADING JOURNEY — WE WANT TO SEE YOU WIN
@@ -118,13 +157,17 @@ export default function CardicNexusLanding() {
                 ))}
               </div>
               <div className='cnx-card-actions'>
-                <a
+                <button
+                  type='button'
                   className='cnx-btn cnx-btn-ghost'
-                  href='#pay'
-                  onClick={scrollToPay}
+                  onClick={() =>
+                    openPay({
+                      ...(p.plan ?? { id: p.title, title: p.title, price: '' }),
+                    })
+                  }
                 >
                   Buy
-                </a>
+                </button>
                 <a className='cnx-btn cnx-btn-blue' href='#contact'>
                   Details
                 </a>
@@ -435,6 +478,12 @@ export default function CardicNexusLanding() {
         All rights reserved.
       </footer>
 
+      <PaymentSheet
+        open={payOpen}
+        onClose={() => setPayOpen(false)}
+        plan={plan}
+      />
+
       {/* Scoped CSS (no Tailwind) */}
       <style>{`
         :root{
@@ -478,6 +527,8 @@ export default function CardicNexusLanding() {
         .cnx-tag{color:#b6beca; margin:12px 0 18px}
         .cnx-row{display:flex; gap:12px; justify-content:center; flex-wrap:wrap}
         .cnx-note{color:#cfe0ff; font-size:14px; margin-top:12px; font-weight:700; letter-spacing:.02em}
+        .cnx-text-gold{color:var(--gold)}
+        .cnx-text-blue{color:var(--blue)}
 
         .cnx-section{max-width:1100px; margin:0 auto; padding:34px 16px}
         .cnx-section h2{margin:0 0 14px; font-size:24px}

--- a/src/components/PaymentSheet.tsx
+++ b/src/components/PaymentSheet.tsx
@@ -1,0 +1,172 @@
+'use client';
+import React from 'react';
+
+type Plan = { id: string; title: string; price: string; features?: string[] };
+type Props = { open: boolean; onClose: () => void; plan?: Plan | null };
+
+export default function PaymentSheet({ open, onClose, plan }: Props) {
+  if (!open) return null;
+  return (
+    <div
+      aria-modal
+      role='dialog'
+      className='cnx-pay-overlay'
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className='cnx-pay-sheet'>
+        <button className='cnx-pay-close' onClick={onClose} aria-label='Close'>
+          ×
+        </button>
+        <h3 className='cnx-pay-title'>{plan?.title ?? 'Complete Purchase'}</h3>
+        {plan?.price && <div className='cnx-pay-price'>{plan.price}</div>}
+
+        <div className='cnx-pay-box'>
+          <h4>Crypto Payment (USDT-ERC20)</h4>
+          <p>Send the amount for your plan, then upload proof below.</p>
+          <div className='cnx-pay-row'>
+            <span>Wallet:</span>
+            <code id='cnx-wallet'>0xYOURWALLETADDRESS</code>
+            <button
+              className='cnx-copy'
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText('0xYOURWALLETADDRESS');
+                  alert('Wallet copied');
+                } catch {
+                  /* ignore */
+                }
+              }}
+            >
+              Copy
+            </button>
+          </div>
+        </div>
+
+        <form
+          className='cnx-form'
+          onSubmit={async (e) => {
+            e.preventDefault();
+            const data = new FormData(e.currentTarget);
+            const res = await fetch('/api/submit-payment', {
+              method: 'POST',
+              body: data,
+            });
+            if (res.ok) {
+              alert('Submitted! We’ll email you shortly.');
+              onClose();
+              e.currentTarget.reset();
+            } else {
+              alert('Something went wrong. Please try again.');
+            }
+          }}
+        >
+          <input name='plan' defaultValue={plan?.id ?? ''} hidden />
+          <label>
+            Full name
+            <input name='name' required />
+          </label>
+          <label>
+            Email
+            <input name='email' type='email' required />
+          </label>
+          <label>
+            TradingView username
+            <input name='tradingview' required />
+          </label>
+          <label>
+            Proof of payment
+            <input
+              name='proof'
+              type='file'
+              accept='image/*,application/pdf'
+              required
+            />
+          </label>
+          <button className='cnx-btn cnx-btn-blue' type='submit'>
+            Submit
+          </button>
+        </form>
+      </div>
+
+      <style jsx>{`
+        .cnx-pay-overlay {
+          position: fixed;
+          inset: 0;
+          background: rgba(0, 0, 0, 0.6);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          z-index: 80;
+        }
+        .cnx-pay-sheet {
+          width: min(560px, 92vw);
+          background: #0f1115;
+          border: 1px solid rgba(255, 255, 255, 0.12);
+          border-radius: 16px;
+          padding: 18px;
+          box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+          position: relative;
+        }
+        .cnx-pay-close {
+          position: absolute;
+          right: 12px;
+          top: 8px;
+          background: transparent;
+          border: 0;
+          color: #fff;
+          font-size: 24px;
+          cursor: pointer;
+        }
+        .cnx-pay-title {
+          margin: 6px 0 4px;
+          font-size: 20px;
+        }
+        .cnx-pay-price {
+          color: #10a5ff;
+          font-weight: 800;
+          margin-bottom: 8px;
+        }
+        .cnx-pay-box {
+          background: rgba(255, 255, 255, 0.04);
+          border: 1px solid rgba(255, 255, 255, 0.12);
+          border-radius: 12px;
+          padding: 12px;
+          margin: 10px 0;
+        }
+        .cnx-pay-row {
+          display: flex;
+          gap: 8px;
+          align-items: center;
+          flex-wrap: wrap;
+        }
+        .cnx-copy {
+          padding: 6px 10px;
+          border: 1px solid rgba(255, 255, 255, 0.2);
+          border-radius: 10px;
+          background: transparent;
+          color: #fff;
+        }
+        .cnx-form {
+          display: grid;
+          gap: 10px;
+          margin-top: 10px;
+        }
+        .cnx-form label {
+          display: grid;
+          gap: 6px;
+          font-size: 14px;
+          color: #cfd3dc;
+        }
+        .cnx-form input {
+          background: #0b0d11;
+          border: 1px solid rgba(255, 255, 255, 0.14);
+          border-radius: 10px;
+          padding: 10px;
+          color: #fff;
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side PaymentSheet modal with crypto wallet copy and proof submission form
- wire the hero Join Premium CTA and project Buy buttons to open the modal while preserving existing styling
- define plan metadata on project cards and mount the PaymentSheet on the landing page

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9f49394a08320b462a432d1e4bb3b