### PR TITLE
Update partner program terminology to NP branding

### DIFF
--- a/src/app/api/partner/apply/route.ts
+++ b/src/app/api/partner/apply/route.ts
@@ -93,9 +93,9 @@ export async function POST(request: Request) {
       throw new EmailError('Missing ADMIN_EMAIL environment variable');
     }
 
-    const adminSubject = `New IB application — ${legalName}`;
+    const adminSubject = `New NP application — ${legalName}`;
     const adminText = [
-      'A new introducer (IB) application has been submitted.',
+      'A new Nexus Partner (NP) application has been submitted.',
       `Legal name: ${legalName}`,
       `Email: ${email}`,
       `Country: ${country}`,
@@ -119,11 +119,11 @@ export async function POST(request: Request) {
       attachments: attachments.length ? attachments : undefined,
     });
 
-    const userSubject = 'We received your Cardic Nexus IB application';
+    const userSubject = 'We received your Cardic Nexus NP application';
     const userText = [
       `Hi ${legalName},`,
       '',
-      'Thanks for applying to become an Introducer (IB) with Cardic Nexus.',
+      'Thanks for applying to become a Nexus Partner (NP) with Cardic Nexus.',
       'Our partnerships team is reviewing your submission and will follow up shortly.',
       '',
       'What we received:',

--- a/src/app/partner/page.tsx
+++ b/src/app/partner/page.tsx
@@ -151,7 +151,10 @@ export default function PartnerPage() {
       <section className='hero'>
         <div className='hero-inner'>
           <p className='eyebrow'>Cardic Nexus Partner Hub</p>
-          <h1>Mint your referral link. Apply as an IB. Earn 35% for life.</h1>
+          <h1>
+            Mint your referral link. Apply as an NP (NEXUS PARTNER). Earn 35%
+            for life.
+          </h1>
           <p className='subcopy'>
             Secure a 35% lifetime revenue share on every active subscription you
             introduce. Transparent dashboards, bank-grade tracking, and weekly
@@ -162,7 +165,7 @@ export default function PartnerPage() {
               Mint referral code
             </a>
             <a href='#ib' className='cta secondary'>
-              Submit IB application
+              Submit NP application
             </a>
           </div>
         </div>
@@ -261,7 +264,7 @@ export default function PartnerPage() {
 
         <article id='ib' className='card ib-card'>
           <header>
-            <h2>Introducer (IB) Application</h2>
+            <h2>Nexus Partner (NP) Application</h2>
             <p>
               Tell us about your reach and how you’ll represent Cardic Nexus. We
               review every partner manually to protect brand integrity.
@@ -405,7 +408,7 @@ export default function PartnerPage() {
               </p>
             ) : null}
             <button type='submit' className='submit' disabled={ibLoading}>
-              {ibLoading ? 'Submitting…' : 'Submit IB application'}
+              {ibLoading ? 'Submitting…' : 'Submit NP application'}
             </button>
           </form>
         </article>
@@ -482,7 +485,7 @@ export default function PartnerPage() {
           Mint my referral code
         </a>
         <a href='#ib' className='cta secondary'>
-          Submit IB application
+          Submit NP application
         </a>
         <a
           href='https://t.me/realcardic1'

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -51,7 +51,7 @@ export default function NavBar() {
 
         <div className='cnx-nav-actions'>
           <Link href='/partner' className='cnx-btn cnx-btn-amber'>
-            Refer &amp; Earn (IB Program)
+            NP (NEXUS PARTNER)
           </Link>
           <a href='#pay' onClick={onNavClick} className='cnx-btn cnx-btn-blue'>
             Join Premium
@@ -103,7 +103,7 @@ export default function NavBar() {
             className='cnx-btn cnx-btn-amber'
             onClick={() => setOpen(false)}
           >
-            Refer &amp; Earn (IB Program)
+            NP (NEXUS PARTNER)
           </Link>
           <a
             href='#pay'


### PR DESCRIPTION
## Summary
- replace "Refer & Earn (IB Program)" nav actions with the new NP (NEXUS PARTNER) wording
- refresh the partner landing page hero, CTA labels, and application heading to reference the NP program
- update partner application emails to use the Nexus Partner (NP) terminology

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e5ea18f48320872666ac6b293d92